### PR TITLE
Added episode rendering, win% metric. Halved # of 'loading checkpoint' messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ print_checkpoint=True: Whether to printout checkpoint saves
 print_saves=True: Whether to printout param saves
 ```
 
+## won(rewards)
+Outputs 1 if sum(rewards)>100, 0 otherwise
+
 ## play_episode(model, half_turn_limit=2000, print_rewards=True, render=False, render_delay=1)
-Plays a single game of chess with the model against itself and outputs raw training data
+Plays a single game of chess with the model against itself and outputs raw training data and a dictionary containing metrics, currently just whether the game was won.
 
 Parameters:
 ```

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ print_checkpoint=True: Whether to printout checkpoint saves
 print_saves=True: Whether to printout param saves
 ```
 
-## play_episode(model, half_turn_limit=2000, print_rewards=True)
+## play_episode(model, half_turn_limit=2000, print_rewards=True, render=False, render_delay=1)
 Plays a single game of chess with the model against itself and outputs raw training data
 
 Parameters:
@@ -127,6 +127,8 @@ Parameters:
 model: The base container class of the model to be saved
 half_turn_limit=2000: The number of individual moves before this will terminate without waiting for the game to end
 print_rewards=True: If true this will print out the total of all rewards and the number of moves made
+render=False: If true the env will be rendered after every move
+render_delay=1: Delay in seconds between moves when rendering the board
 ```
 
 ## generate_data(model, num_games, discount_factor)

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ model: The base container class of the model to be saved
 print_out=True: When True this will print a message to the console with the models current epoch
 ```
 
-## load_checkpoint(model)
+## load_checkpoint(model, print_out=True)
 Loads a checkpoint for a model. Currently used in the model class init if a checkpoint for that model is present.
 
 Parameters:
 ```
 model: The base container class of the model to be saved
+print_out=True: When True this will print a message to the console
 ```
 
 ## initialize_weights(modules, mean=0.0, variance=0.1, bias=0)
@@ -161,13 +162,14 @@ Parameters:
 'loss_function': The loss function to use
 ```
 
-## init(self, use_cuda=True, resume=True)
+## init(self, parent_process=True, use_cuda=True, resume=True)
 The classes init which sets whether cuda is used and loads a checkpoint if one exists, or initialized weights if it doesn't.
 
 Parameters:
 ```
 use_cuda=True: Whether cuda should be used.
 resume=True: If this is false new weights will be initialized no matter what. Be careful with this because the models old parameters will be overwritten.
+parent_process=True: This is set to false for async processes and determines whether to print the loading_checkpoint message. Unfortunately the async processes call init twice with the first time using the same params as main process so it still prints out the message, but at least it only prints 5 instead of 10 now. I have no idea why this is the case.
 ```
 
 ## cuda(self)

--- a/classes/base_model.py
+++ b/classes/base_model.py
@@ -43,24 +43,18 @@ def generate_class(params):
         print('check_params failed')
         return None
 
-    def init(self, use_cuda=True, resume=True):
-        ''''
-        Most of these attributes should be moved to the attrs dict
-        It would help readability and avoid some inheritence
-        collisions if that ever comes up
-        '''
+    def init(self, parent_process=True, use_cuda=True, resume=True):
+
         self.use_cuda = use_cuda and torch.cuda.is_available()
-        # We might have to add logic in here to set the filepath, not sure
         if self.use_cuda:
             self.cuda()
             # From what I can tell this is what actually enables cuda
             self.feed_forward.cuda()
-        '''
-        I'm fairly certain I broke saves/checkpoints
-        '''
+
         if resume:
             # TODO decide a pattern for filenames
-            if not utils.load_checkpoint(self):
+
+            if not utils.load_checkpoint(self, print_out=parent_process):
                 self.epoch = 0
                 utils.initialize_weights(self.feed_forward.modules())
         else:

--- a/classes/utils.py
+++ b/classes/utils.py
@@ -41,16 +41,18 @@ def save_checkpoint(model, print_out=True):
     torch.save(state, filepath)
 
 
-def load_checkpoint(model):
+def load_checkpoint(model, print_out=True):
     filepath = get_filepath(model.name, True)
     if os.path.isfile(filepath):
-        print("=> loading checkpoint '{}'".format(filepath))
+        if print_out:
+            print("=> loading checkpoint '{}'".format(filepath))
         checkpoint = torch.load(filepath)
         model.epoch = checkpoint['epoch']
         model.feed_forward.load_state_dict(checkpoint['state_dict'])
         model.optimizer.load_state_dict(checkpoint['optimizer'])
-        print("=> loaded checkpoint '{}' (epoch {})"
-              .format(filepath, checkpoint['epoch']))
+        if print_out:
+            print("=> loaded checkpoint '{}' (epoch {})"
+                  .format(filepath, checkpoint['epoch']))
         return True
     else:
         print("=> no checkpoint found at '{}'".format(filepath))

--- a/classes/utils.py
+++ b/classes/utils.py
@@ -2,6 +2,7 @@ import torch
 import os
 import numpy as np
 import torch.utils.data as data_utils
+import time
 
 use_cuda = torch.cuda.is_available()
 FloatTensor = torch.cuda.FloatTensor if use_cuda else torch.FloatTensor
@@ -163,12 +164,15 @@ def training_session(model, dataloader, n_epochs,
                 save_params(model, print_out=print_saves)
 
 
-def play_episode(model, half_turn_limit=2000, print_rewards=True):
+def play_episode(model, half_turn_limit=2000, print_rewards=True, render=False, render_delay=1):
     model.env._reset()
     states = []
     rewards = []
     i = 0
     while True:
+        if render:
+            model.env._render()
+            time.sleep(render_delay)
         a = model.perform_action()
         states.append(a['state'])
         rewards.append(a['reward'])

--- a/runtimes/test.py
+++ b/runtimes/test.py
@@ -79,3 +79,4 @@ if __name__ == '__main__':
                                starting_index=0,
                                print_checkpoint=True,
                                print_saves=True)
+    utils.play_episode(run, render=True)

--- a/runtimes/test.py
+++ b/runtimes/test.py
@@ -10,6 +10,7 @@ for path in sys.path:
 if do_modify:
     sys.path.insert(0, proj_path)
 
+import os
 from torch.multiprocessing import Pool
 
 from classes import utils
@@ -41,28 +42,21 @@ if __name__ == '__main__':
 
     utils.ensure_dir(utils.SAVE_DIR)
 
-    def async(threads):
+    def async(n_threads):
         stack = []
-        with Pool(processes=threads) as pool:
-            res = pool.apply_async(pack_episode)
-            res1 = pool.apply_async(pack_episode)
-            res2 = pool.apply_async(pack_episode)
-            res3 = pool.apply_async(pack_episode)
-            res4 = pool.apply_async(pack_episode)
-            stack.append(res.get())
-            stack.append(res1.get())
-            stack.append(res2.get())
-            stack.append(res3.get())
-            stack.append(res4.get())
-        return stack
+        with Pool(processes=n_threads) as pool:
+            results = [pool.apply_async(pack_episode) for _ in range(n_threads)]
+            for res in results:
+                stack.append(res.get())
+            return stack
 
-    def async_generate_data():
-        data = async(5)
+    def async_generate_data(n_threads = os.cpu_count() if os.cpu_count() else 4):
+        data = async(n_threads)
         rewards_stack = []
         states_stack = []
         c = 0
         metrics = {'wins': 0}
-        for _ in range(5):
+        for _ in range(n_threads):
             c += 1
             a = data.pop()
             rewards_stack += a['rewards']


### PR DESCRIPTION
Added param to render env in utils.play_episode(). Added metric for % of games not drawn. Tried to make async processes not print the 'loading checkpoint' message, but the processes call init() twice for some reason and the first call uses the same params as the main class instance so I just made half of those messages not appear.